### PR TITLE
use end instead of sys flush for python 3

### DIFF
--- a/arp_spoof/arp_spoof.py
+++ b/arp_spoof/arp_spoof.py
@@ -2,7 +2,6 @@
 
 import scapy.all as scapy
 import time
-import sys
 
 
 def get_mac(ip):
@@ -28,6 +27,5 @@ while True:
     spoof("192.168.124.142", "192.168.124.2")
     spoof("192.168.124.2", "192.168.124.142")
     sent_packets_count += 2
-    print("\r[+] Sent packets: " + str(sent_packets_count)),
-    sys.stdout.flush()
+    print("\r[+] Sent packets: " + str(sent_packets_count), end="")
     time.sleep(2)


### PR DESCRIPTION
Once Python 3 compatible solution for Scapy is implemented in issue https://github.com/h3xar0n/bivittatus/issues/1 , this can be merged to make the ARP spoofer compatible as well.